### PR TITLE
[BUGFIX] Adapt key length on DN for InnoDB tables

### DIFF
--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -52,7 +52,7 @@ CREATE TABLE be_groups (
 	tx_igldapssoauth_dn varchar(255) DEFAULT '' NOT NULL,
 
 	KEY title (title),
-	KEY tx_igldapssoauth_dn (tx_igldapssoauth_dn)
+	KEY tx_igldapssoauth_dn (tx_igldapssoauth_dn(64))
 );
 
 #
@@ -62,7 +62,7 @@ CREATE TABLE be_users (
 	tx_igldapssoauth_dn varchar(255) DEFAULT '' NOT NULL,
 	tx_igldapssoauth_id int(11) unsigned DEFAULT '0' NOT NULL,
 
-	KEY tx_igldapssoauth_dn (tx_igldapssoauth_dn)
+	KEY tx_igldapssoauth_dn (tx_igldapssoauth_dn(64))
 );
 
 #
@@ -72,7 +72,7 @@ CREATE TABLE fe_groups (
 	tx_igldapssoauth_dn varchar(255) DEFAULT '' NOT NULL,
 
 	KEY title (title),
-	KEY tx_igldapssoauth_dn (tx_igldapssoauth_dn)
+	KEY tx_igldapssoauth_dn (tx_igldapssoauth_dn(64))
 );
 
 #
@@ -82,5 +82,5 @@ CREATE TABLE fe_users (
 	tx_igldapssoauth_dn varchar(255) DEFAULT '' NOT NULL,
 	tx_igldapssoauth_id int(11) unsigned DEFAULT '0' NOT NULL,
 
-	KEY tx_igldapssoauth_dn (tx_igldapssoauth_dn)
+	KEY tx_igldapssoauth_dn (tx_igldapssoauth_dn(64))
 );


### PR DESCRIPTION
According to https://dev.mysql.com/doc/refman/5.7/en/innodb-restrictions.html,
an InnoDB table has an index key prefix limit of 767 bytes if configuration
parameter `innodb_large_prefix` is disabled.

By constraining the DN key to 64 characters, we should still have a good
discriminant index while preventing errors when trying to create the index
in the Install Tool.

Resolves: #9