### PR TITLE
[fix] Escape Backslashes for LDAP-Search and in Javascript

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -343,6 +343,7 @@ class ModuleController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
 
         if ($success) {
             list($filter, $baseDn) = Authentication::getRelativeDistinguishedNames($dn, 2);
+            $filter = str_replace('\\','',$filter);
             $ldapUser = $this->ldap->search($baseDn, '(' . $filter . ')', [], true);
             $typo3Users = $importUtility->fetchTypo3Users([$ldapUser]);
 

--- a/Resources/Public/JavaScript/import.js
+++ b/Resources/Public/JavaScript/import.js
@@ -44,6 +44,7 @@ IgLdapSsoAuthImport = {
         IgLdapSsoAuthImport.fields.form.submit(function (e) {
             e.preventDefault(); // this will prevent from submitting the form
             var dn = $('#tx-igldapssoauth-dn').val();
+            dn=dn.replace('\\','\\\\');
             IgLdapSsoAuthImport.ldapImport($("button[value='" + dn + "']").closest('tr'));
         });
     });


### PR DESCRIPTION
Importing LDAP User from Backend fails if DN contains Backslashes
Example:
CN=Firstname\\, Lastname,OU=Users,OU=someOU,DC=myOrg,DC=local

Not sure if this is a legal CN, it comes from our LDAP Server and i can do nothing about it.
The Backslash has to be escaped for ldap_search.
The Javascript Selector need escaping too.
