### PR TITLE
[BUGFIX] Pass LDAP arguments during AJAX import

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -343,7 +343,8 @@ class ModuleController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
 
         if ($success) {
             list($filter, $baseDn) = Authentication::getRelativeDistinguishedNames($dn, 2);
-            $ldapUser = $this->ldap->search($baseDn, '(' . $filter . ')', [], true);
+            $attributes = Configuration::getLdapAttributes($config['users']['mapping']);
+            $ldapUser = $this->ldap->search($baseDn, '(' . $filter . ')', $attributes, true);
             $typo3Users = $importUtility->fetchTypo3Users([$ldapUser]);
 
             // Merge LDAP and TYPO3 information
@@ -434,7 +435,8 @@ class ModuleController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
 
         if ($success) {
             list($filter, $baseDn) = explode(',', $dn, 2);
-            $ldapGroup = $this->ldap->search($baseDn, '(' . $filter . ')', [], true);
+            $attributes = Configuration::getLdapAttributes($config['groups']['mapping']);
+            $ldapGroup = $this->ldap->search($baseDn, '(' . $filter . ')', $attributes, true);
 
             $pid = Configuration::getPid($config['groups']['mapping']);
             $table = $mode === 'be' ? 'be_groups' : 'fe_groups';


### PR DESCRIPTION
If a user is imported manually using the backend module,
then the import doesn’t use the configured attributes for the LDAP server.
The resulting search request therefore may contain incomplete
data and the import will fail.

To fix this we pass the LDAP attributes from the mapping
as given in the LDAP configuration.

Refs #15