### PR TITLE
Better cleaning of empty values

### DIFF
--- a/Classes/Library/Configuration.php
+++ b/Classes/Library/Configuration.php
@@ -212,7 +212,7 @@ class Configuration
         $keys = array_keys($setup);
         foreach ($keys as $key) {
             if (substr($key, -1) !== '.') {
-                if (empty($setup[$key])) {
+                if ($setup[$key] === '') {
                     unset($setup[$key]);
                 }
             }


### PR DESCRIPTION
If we want to map values for boolean fields, and wish to set the value to 0, the mapped value is unset when mapping is parsed. 
With this change, the parsing allows you to set 0 for boolean fields in the mapping config