### PR TITLE
-fixed logging (comma typo)

### DIFF
--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -233,7 +233,7 @@ class AuthenticationService extends \TYPO3\CMS\Sv\AuthenticationService
                 return static::STATUS_AUTHENTICATION_FAILURE_CONTINUE;
             } else {
                 // Failed login attempt (wrong password) - write that to the log!
-                static::getLogger()->warning('Password not accepted: ' . [
+                static::getLogger()->warning('Password not accepted: ' , [
                         'username' => $this->login['uname'],
                         'remote' => sprintf('%s (%s)', $this->authInfo['REMOTE_ADDR'], $this->authInfo['REMOTE_HOST']),
                     ]);


### PR DESCRIPTION
They logger will only log "Password not accepted: Array" , i guess this is just a typo - because the concatenation there makes no sense to me