### PR TITLE
[BUGFIX] BE user creation on login.

### DIFF
--- a/Classes/Domain/Repository/Typo3UserRepository.php
+++ b/Classes/Domain/Repository/Typo3UserRepository.php
@@ -180,14 +180,13 @@ class Typo3UserRepository
 
         $uid = $tableConnection->lastInsertId();
 
-        $newRow = $tableConnection
-            ->select(
-                ['*'],
-                $table,
-                [
-                    'uid' => $uid,
-                ]
-            )
+        $queryBuilder = $tableConnection->createQueryBuilder();
+        $queryBuilder->getRestrictions()->removeAll();
+        $newRow = $queryBuilder
+            ->select('*')
+            ->from($table)
+            ->andWhere($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid)))
+            ->execute()
             ->fetch();
 
         NotificationUtility::dispatch(


### PR DESCRIPTION
If a BE user does not yet exists in the DB it should be created after successful LDAP authentication. The user is first created with default values ([`Authentication:195`](https://github.com/xperseguers/t3ext-ig_ldap_sso_auth/blob/b7c3366553e526fd57489ac66d07a081add5aadc/Classes/Library/Authentication.php#L195)) and afterwards updated with mapped LDAP values ([`Authentication:230`](https://github.com/xperseguers/t3ext-ig_ldap_sso_auth/blob/b7c3366553e526fd57489ac66d07a081add5aadc/Classes/Library/Authentication.php#L230)). In TYPO3 v9 the field `disable` has the default value `1` which means after first creating the user it cannot be found by  [`Typo3UserRepository:184`](https://github.com/xperseguers/t3ext-ig_ldap_sso_auth/blob/b7c3366553e526fd57489ac66d07a081add5aadc/Classes/Domain/Repository/Typo3UserRepository.php#L184) since this field is one of the `enablecolumns` (`Restrictions`).

This patch uses the `QueryBuilder` to remove all `Restrictions` (`disable` fields) from the select instead of using the `$tableConnection`s `select` directly (which enables all `Restrictions` by default).

Since there was no restriction before [`Typo3UserRepository:159`](https://github.com/xperseguers/t3ext-ig_ldap_sso_auth/blob/056876af8c0fb28efa11591e447b5d9b242eae5b/Classes/Domain/Repository/Typo3UserRepository.php#L159) this should be back to the original behavior.