### PR TITLE
[Bugfix] Escape backslashes for LDAP search

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -442,6 +442,10 @@ class ModuleController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
 
         if ($success) {
             list($filter, $baseDn) = Authentication::getRelativeDistinguishedNames($params['dn'], 2);
+
+            // Escape Backslashes for LDAP-Search
+            $filter = str_replace('\\','',$filter);
+
             $attributes = Configuration::getLdapAttributes($config['users']['mapping']);
             $ldapUser = $ldap->search($baseDn, '(' . $filter . ')', $attributes, true);
             $typo3Users = $importUtility->fetchTypo3Users([$ldapUser]);


### PR DESCRIPTION
The manual import of a ldap user via the backend fails if the dn contains a backslash and needs to escape.

For example:

`CN=Lastname\, Firstname,OU=Users,OU=...,DC=local`

This pull request is similar to this one: https://github.com/xperseguers/t3ext-ig_ldap_sso_auth/pull/13

 