### PR TITLE
fixing baseDn check for GroupDn to become case insensitive

### DIFF
--- a/Classes/Library/LdapGroup.php
+++ b/Classes/Library/LdapGroup.php
@@ -49,7 +49,7 @@ class LdapGroup
         unset($membership['count']);
 
         foreach ($membership as $groupDn) {
-            if (substr($groupDn, -strlen($baseDn)) !== $baseDn) {
+            if ((strcasecmp(substr($groupDn, -strlen($baseDn)), $baseDn)) !== 0) {
                 // Group $groupDn does not match the required baseDn for LDAP groups
                 continue;
             }


### PR DESCRIPTION
All config examples are lowercase which conflicts with the check, but anyway I can't see a reason why this check should be case sensitive, so patching it to make it more user friendly.
https://github.com/xperseguers/t3ext-ig_ldap_sso_auth/issues/56