### PR TITLE
Use hosts from site configurations for domain restriction

### DIFF
--- a/Classes/Domain/Model/Configuration.php
+++ b/Classes/Domain/Model/Configuration.php
@@ -40,6 +40,11 @@ class Configuration
     protected $domains;
 
     /**
+     * @var string
+     */
+    protected $sites;
+
+    /**
      * @var int
      */
     protected $ldapServer;
@@ -230,6 +235,14 @@ class Configuration
     public function getDomains()
     {
         return $this->domains;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSites()
+    {
+        return $this->sites;
     }
 
     /**

--- a/Classes/Domain/Repository/ConfigurationRepository.php
+++ b/Classes/Domain/Repository/ConfigurationRepository.php
@@ -153,6 +153,7 @@ class ConfigurationRepository
         $mapping = [
             'name' => 'name',
             'domains' => 'domains',
+            'sites' => 'sites',
             'ldap_charset' => 'ldapCharset',
             'ldap_host' => 'ldapHost',
             'ldap_binddn' => 'ldapBindDn',

--- a/Classes/Utility/SiteConfigurationItemsProcFunc.php
+++ b/Classes/Utility/SiteConfigurationItemsProcFunc.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace Causal\IgLdapSsoAuth\Utility;
+
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class SiteConfigurationItemsProcFunc
+{
+    /**
+     * @var SiteFinder
+     */
+    protected $siteFinder;
+
+    public function __construct()
+    {
+        $this->siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
+    }
+
+    /**
+     * Fills the item list with pairs of site identifier and host for each available site config.
+     *
+     * @param array $config
+     */
+    public function getSites(array &$config): void
+    {
+        $allSites = $this->siteFinder->getAllSites();
+
+        $config['items'] = array_map(
+            static function (Site $site) {
+                return [
+                    // displayed value
+                    $site->getBase()->getHost(),
+                    // stored value
+                    $site->getIdentifier()
+                ];
+            },
+            $allSites
+        );
+    }
+}

--- a/Configuration/TCA/tx_igldapssoauth_config.php
+++ b/Configuration/TCA/tx_igldapssoauth_config.php
@@ -1,4 +1,6 @@
 <?php
+$sitesField = version_compare(TYPO3_version, '9.0', '>=') ? 'sites,' : '';
+
 return [
     'ctrl' => [
         'title' => 'LLL:EXT:ig_ldap_sso_auth/Resources/Private/Language/locallang_db.xlf:tx_igldapssoauth_config',
@@ -17,7 +19,7 @@ return [
         'iconfile' => 'EXT:ig_ldap_sso_auth/Resources/Public/Icons/icon_tx_igldapssoauth_config.png',
     ],
     'interface' => [
-        'showRecordFieldList' => 'hidden, name, domains,
+        'showRecordFieldList' => 'hidden, name, domains, ' . $sitesField . '
                         ldap_server, ldap_charset, ldap_host, ldap_port, ldap_tls, ldap_ssl, ldap_binddn,
                         ldap_password, group_membership,
                         be_users_basedn, be_users_filter, be_users_mapping,
@@ -30,7 +32,7 @@ return [
         '1' => [
             'showitem' => '
                     --div--;GENERAL,
-                        hidden, name, domains,
+                        hidden, name, domains, ' . $sitesField . '
                     --div--;LDAP,
                         ldap_server, ldap_charset,
                     --palette--;LLL:EXT:ig_ldap_sso_auth/Resources/Private/Language/locallang_db.xlf:palette.connection;connection,
@@ -79,6 +81,17 @@ return [
                 'size' => 10,
                 'minitems' => 0,
                 'maxitems' => 999,
+            ]
+        ],
+        'sites' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:ig_ldap_sso_auth/Resources/Private/Language/locallang_db.xlf:tx_igldapssoauth_config.sites',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectMultipleSideBySide',
+                'itemsProcFunc' => \Causal\IgLdapSsoAuth\Utility\SiteConfigurationItemsProcFunc::class . '->getSites',
+                'allowNonIdValues' => true,
+                'size' => 10,
             ]
         ],
         'ldap_server' => [

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -69,6 +69,9 @@
 			<trans-unit id="tx_igldapssoauth_config.domains">
 				<source>Associated domains:</source>
 			</trans-unit>
+			<trans-unit id="tx_igldapssoauth_config.sites">
+				<source>Associated site configurations:</source>
+			</trans-unit>
 
 			<trans-unit id="tx_igldapssoauth_config.ldap_server">
 				<source>Server Type:</source>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -13,6 +13,7 @@ CREATE TABLE tx_igldapssoauth_config (
 
 	name varchar(255) DEFAULT '' NOT NULL,
 	domains text NOT NULL,
+	sites text NOT NULL,
 	ldap_server int(11) DEFAULT '0' NOT NULL,
 	ldap_charset varchar(255) DEFAULT '' NOT NULL,
 	ldap_host varchar(255) DEFAULT '' NOT NULL,


### PR DESCRIPTION
Hi there,

we currently have a project where we try to remove the need for sys_domain records. One last thing was the host validation of this extension using only sys_domain records.

- This PR adds a field to the configuration model for storing site configurations.

- The hosts of those site configurations are then included in the list of domains checked by the extensions AuthenticationService.

- The TYPO3 Core API SiteFinder is used to get the site configurations and resolve the currently used variant and its host.

I'm very much open for suggestions regarding the changes. :)

kind regards,
jona