### PR TITLE
Support of ldaptls_reqcert option

### DIFF
--- a/Classes/Domain/Model/Configuration.php
+++ b/Classes/Domain/Model/Configuration.php
@@ -73,6 +73,11 @@ class Configuration
     /**
      * @var bool
      */
+    protected $ldapTlsReqcert = true;
+
+    /**
+     * @var bool
+     */
     protected $ldapSsl;
 
     /**
@@ -287,6 +292,22 @@ class Configuration
     public function isLdapSsl()
     {
         return $this->ldapSsl;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isLdapTlsReqcert(): bool
+    {
+        return $this->ldapTlsReqcert;
+    }
+
+    /**
+     * @param bool $ldapTlsReqcert
+     */
+    public function setLdapTlsReqcert(bool $ldapTlsReqcert): void
+    {
+        $this->ldapTlsReqcert = $ldapTlsReqcert;
     }
 
     /**

--- a/Classes/Domain/Repository/ConfigurationRepository.php
+++ b/Classes/Domain/Repository/ConfigurationRepository.php
@@ -157,6 +157,7 @@ class ConfigurationRepository
             'ldap_host' => 'ldapHost',
             'ldap_binddn' => 'ldapBindDn',
             'ldap_password' => 'ldapPassword',
+            'ldap_tls_reqcert' => 'ldapTlsReqcert',
             'be_users_basedn' => 'backendUsersBaseDn',
             'be_users_filter' => 'backendUsersFilter',
             'be_users_mapping' => 'backendUsersMapping',

--- a/Classes/Library/Configuration.php
+++ b/Classes/Library/Configuration.php
@@ -132,6 +132,7 @@ class Configuration
         static::$ldap['host'] = $configuration->getLdapHost();
         static::$ldap['port'] = $configuration->getLdapPort();
         static::$ldap['tls'] = $configuration->isLdapTls();
+        static::$ldap['tlsReqcert'] = $configuration->isLdapTlsReqcert();
         static::$ldap['ssl'] = $configuration->isLdapSsl();
         static::$ldap['binddn'] = $configuration->getLdapBindDn();
         static::$ldap['password'] = $configuration->getLdapPassword();

--- a/Classes/Library/Ldap.php
+++ b/Classes/Library/Ldap.php
@@ -72,7 +72,7 @@ class Ldap
             'ssl' => $config['ssl'],
         ];
         // Connect to ldap server.
-        if (!$this->ldapUtility->connect($config['host'], $config['port'], $config['protocol'], $config['charset'], $config['server'], $config['tls'], $config['ssl'], $config['ssl'], $config['tlsReqcert'])) {
+        if (!$this->ldapUtility->connect($config['host'], $config['port'], $config['protocol'], $config['charset'], $config['server'], $config['tls'], $config['ssl'], $config['tlsReqcert'])) {
             static::getLogger()->error( 'Cannot connect', $debugConfiguration);
             return false;
         }

--- a/Classes/Library/Ldap.php
+++ b/Classes/Library/Ldap.php
@@ -68,12 +68,12 @@ class Ldap
             'charset' => $config['charset'],
             'server' => $config['server'],
             'tls' => $config['tls'],
+            'tlsReqcert' => $config['tlsReqcert'],
             'ssl' => $config['ssl'],
         ];
-
         // Connect to ldap server.
-        if (!$this->ldapUtility->connect($config['host'], $config['port'], $config['protocol'], $config['charset'], $config['server'], $config['tls'], $config['ssl'])) {
-            static::getLogger()->error('Cannot connect', $debugConfiguration);
+        if (!$this->ldapUtility->connect($config['host'], $config['port'], $config['protocol'], $config['charset'], $config['server'], $config['tls'], $config['ssl'], $config['ssl'], $config['tlsReqcert'])) {
+            static::getLogger()->error( 'Cannot connect', $debugConfiguration);
             return false;
         }
 

--- a/Classes/Utility/LdapUtility.php
+++ b/Classes/Utility/LdapUtility.php
@@ -114,11 +114,16 @@ class LdapUtility
      * @param int $serverType 0 = OpenLDAP, 1 = Active Directory
      * @param bool $tls
      * @param bool $ssl
+     * @param bool $tlsReqcert
      * @return bool true if connection succeeded.
      * @throws UnresolvedPhpDependencyException when LDAP extension for PHP is not available
      */
-    public function connect($host = null, $port = null, $protocol = null, $characterSet = null, $serverType = 0, $tls = false, $ssl = false)
+    public function connect($host = null, $port = null, $protocol = null, $characterSet = null, $serverType = 0, $tls = false, $ssl = false, $tlsReqcert = false)
     {
+        if ($tlsReqcert === false) {
+            putenv('LDAPTLS_REQCERT=never');
+        }
+
         // Valid if php load ldap module.
         if (!extension_loaded('ldap')) {
             throw new UnresolvedPhpDependencyException('Your PHP version seems to lack LDAP support. Please install/activate the extension.', 1409566275);

--- a/Configuration/TCA/tx_igldapssoauth_config.php
+++ b/Configuration/TCA/tx_igldapssoauth_config.php
@@ -47,7 +47,7 @@ return [
     ],
     'palettes' => [
         'connection' => [
-            'showitem' => 'ldap_host, ldap_port, ldap_tls, ldap_ssl',
+            'showitem' => 'ldap_host, ldap_port, ldap_tls, ldap_tls_reqcert, ldap_ssl',
             'canNotCollapse' => 1,
         ],
     ],

--- a/Configuration/TCA/tx_igldapssoauth_config.php
+++ b/Configuration/TCA/tx_igldapssoauth_config.php
@@ -142,6 +142,14 @@ return [
                 'default' => '0',
             ]
         ],
+        'ldap_tls_reqcert' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:ig_ldap_sso_auth/Resources/Private/Language/locallang_db.xlf:tx_igldapssoauth_config.ldap_tls_reqcert',
+            'config' => [
+                'type' => 'check',
+                'default' => '1',
+            ]
+        ],
         'ldap_ssl' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:ig_ldap_sso_auth/Resources/Private/Language/locallang_db.xlf:tx_igldapssoauth_config.ldap_ssl',

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -91,6 +91,9 @@
 			<trans-unit id="tx_igldapssoauth_config.ldap_tls">
 				<source>Use TLS:</source>
 			</trans-unit>
+			<trans-unit id="tx_igldapssoauth_config.ldap_tls_reqcert">
+				<source>TLS require cert:</source>
+			</trans-unit>
 			<trans-unit id="tx_igldapssoauth_config.ldap_ssl">
 				<source>Use SSL:</source>
 			</trans-unit>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -18,6 +18,7 @@ CREATE TABLE tx_igldapssoauth_config (
 	ldap_host varchar(255) DEFAULT '' NOT NULL,
 	ldap_port int(11) DEFAULT '0' NOT NULL,
 	ldap_tls tinyint(4) DEFAULT '0' NOT NULL,
+	ldap_tls_reqcert  tinyint(4) DEFAULT '1' NOT NULL,
 	ldap_ssl tinyint(4) DEFAULT '0' NOT NULL,
 	ldap_binddn tinytext NOT NULL,
 	ldap_password varchar(255) DEFAULT '' NOT NULL,


### PR DESCRIPTION
As an admin, I want to set the option "ldap_tls_reqcert" to false. 

Comments:
* I added a TCA field ldap_tls_reqcert, with a default value of true
* the option is set via php in /Classes/Utility/LdapUtility.php line 123