### PR TITLE
This fix the proper ldap_search with Active Directory

### DIFF
--- a/Classes/Library/Ldap.php
+++ b/Classes/Library/Ldap.php
@@ -81,7 +81,7 @@ class Ldap
             'ssl' => $config['ssl'],
         ];
         // Connect to ldap server.
-        if (!$this->ldapUtility->connect($config['host'], $config['port'], 3, $config['charset'], $config['server'], $config['tls'], $config['ssl'], $config['tlsReqcert'])) {
+        if (!$this->ldapUtility->connect($config['host'], $config['port'], 3, $config['charset'], Configuration::getServerType($config['server']), $config['tls'], $config['ssl'], $config['tlsReqcert'])) {
             static::getLogger()->error( 'Cannot connect', $debugConfiguration);
             return false;
         }

--- a/Classes/Utility/LdapUtility.php
+++ b/Classes/Utility/LdapUtility.php
@@ -89,8 +89,8 @@ class LdapUtility
     protected $status;
 
     /**
-     * 0 = OpenLDAP, 1 = Active Directory
-     * @var int
+     * 'OpenLDAP' OR 'Active Directory'
+     * @var string
      */
     protected $serverType;
 


### PR DESCRIPTION
Current 3.5.0 changed type of `serverType` from int to string.
Unfortunatly at one point, it remained integer in `Ldap::connect()`. This
causes in `LdapUtility::connect()` the `serverType` to be '1' instead of
'Active Directory'. The setting of LDAP_OPT_REFERRALS is omitted and
`ldap_searchi()` failes with 'Operations error'.