### PR TITLE
[FEATURE] SSO: Keep the domain name after a successfull login

### DIFF
--- a/Classes/Library/Configuration.php
+++ b/Classes/Library/Configuration.php
@@ -113,6 +113,7 @@ class Configuration
 
         static::$be['LDAPAuthentication'] = (bool)$globalConfiguration['enableBELDAPAuthentication'];
         static::$be['SSOAuthentication'] = (bool)$globalConfiguration['enableBESSO'];
+        static::$be['SSOKeepDomainName'] = (bool)$globalConfiguration['keepBESSODomainName'];
         static::$be['forceLowerCaseUsername'] = $globalConfiguration['forceLowerCaseUsername'] ? (bool)$globalConfiguration['forceLowerCaseUsername'] : false;
         static::$be['evaluateGroupsFromMembership'] = $configuration->getGroupMembership() === static::GROUP_MEMBERSHIP_FROM_MEMBER;
         static::$be['IfUserExist'] = (bool)$globalConfiguration['TYPO3BEUserExist'];
@@ -134,6 +135,7 @@ class Configuration
 
         static::$fe['LDAPAuthentication'] = (bool)$globalConfiguration['enableFELDAPAuthentication'];
         static::$fe['SSOAuthentication'] = (bool)$globalConfiguration['enableFESSO'];
+        static::$fe['SSOKeepDomainName'] = (bool)$globalConfiguration['keepFESSODomainName'];
         static::$fe['forceLowerCaseUsername'] = $globalConfiguration['forceLowerCaseUsername'] ? (bool)$globalConfiguration['forceLowerCaseUsername'] : false;
         static::$fe['evaluateGroupsFromMembership'] = $configuration->getGroupMembership() === static::GROUP_MEMBERSHIP_FROM_MEMBER;
         static::$fe['IfUserExist'] = (bool)$globalConfiguration['TYPO3FEUserExist'];

--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -128,12 +128,14 @@ class AuthenticationService extends BaseAuthenticationService
             if ($enableFrontendSso || $enableBackendSso) {
                 // Strip the domain name
                 $domain = null;
-                if ($pos = strpos($remoteUser, '@')) {
-                    $domain = substr($remoteUser, $pos + 1);
-                    $remoteUser = substr($remoteUser, 0, $pos);
-                } elseif ($pos = strrpos($remoteUser, '\\')) {
-                    $domain = substr($remoteUser, 0, $pos);
-                    $remoteUser = substr($remoteUser, $pos + 1);
+                if (!Configuration::getValue('SSOKeepDomainName')) {
+                    if ($pos = strpos($remoteUser, '@')) {
+                        $domain = substr($remoteUser, $pos + 1);
+                        $remoteUser = substr($remoteUser, 0, $pos);
+                    } elseif ($pos = strrpos($remoteUser, '\\')) {
+                        $domain = substr($remoteUser, 0, $pos);
+                        $remoteUser = substr($remoteUser, $pos + 1);
+                    }
                 }
 
                 $userRecordOrIsValid = Authentication::ldapAuthenticate($remoteUser, null, $domain);

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -36,6 +36,9 @@
 			<trans-unit id="settings.enableBESSO">
 				<source>Backend SSO: Enable Single Sign-On for Backend users.</source>
 			</trans-unit>
+			<trans-unit id="settings.keepBESSODomainName">
+				<source>Backend SSO: Keep the domain name after a successful login (for example on a CAS-Server), to continue the chain of authentication through LDAP.</source>
+			</trans-unit>
 			<trans-unit id="settings.enableFELDAPAuthentication">
 				<source>Frontend LDAP authentication: Enable LDAP authentication for the frontend.</source>
 			</trans-unit>
@@ -59,6 +62,9 @@
 			</trans-unit>
 			<trans-unit id="settings.enableFESSO">
 				<source>Frontend SSO: Enable Single Sign-On for Frontend users.</source>
+			</trans-unit>
+			<trans-unit id="settings.keepFESSODomainName">
+				<source>Frontend SSO: Keep the domain name after a successful login (for example on a CAS-Server), to continue the chain of authentication through LDAP.</source>
 			</trans-unit>
 			<trans-unit id="tx_igldapssoauth_config">
 				<source>Configuration LDAP / SSO</source>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -28,6 +28,9 @@ keepBEGroups = 0
 # cat=backend/enable; type=boolean; label=LLL:EXT:ig_ldap_sso_auth/Resources/Private/Language/locallang_db.xlf:settings.enableBESSO
 enableBESSO = 0
 
+# cat=backend/enable; type=boolean; label=LLL:EXT:ig_ldap_sso_auth/Resources/Private/Language/locallang_db.xlf:settings.keepBESSODomainName
+keepBESSODomainName = 0
+
 # cat=frontend/enable/1; type=boolean; label=LLL:EXT:ig_ldap_sso_auth/Resources/Private/Language/locallang_db.xlf:settings.enableFELDAPAuthentication
 enableFELDAPAuthentication = 0
 
@@ -52,3 +55,5 @@ keepFEGroups = 0
 # cat=frontend/enable; type=boolean; label=LLL:EXT:ig_ldap_sso_auth/Resources/Private/Language/locallang_db.xlf:settings.enableFESSO
 enableFESSO = 0
 
+# cat=frontend/enable; type=boolean; label=LLL:EXT:ig_ldap_sso_auth/Resources/Private/Language/locallang_db.xlf:settings.keepFESSODomainName
+keepFESSODomainName = 0


### PR DESCRIPTION
This is useful e.g., on a CAS-Server, to continue the chain of authentication
through LDAP.

Resolves: #81