### PR TITLE
Fix exception on backend login due to missing initialization of ldapTlsReqcert

### DIFF
--- a/Classes/Domain/Model/Configuration.php
+++ b/Classes/Domain/Model/Configuration.php
@@ -78,7 +78,7 @@ class Configuration
     /**
      * @var bool
      */
-    protected $ldapTlsReqcert = true;
+    protected $ldapTlsReqcert;
 
     /**
      * @var bool

--- a/Classes/Domain/Repository/ConfigurationRepository.php
+++ b/Classes/Domain/Repository/ConfigurationRepository.php
@@ -207,6 +207,7 @@ class ConfigurationRepository
         $object->_setProperty('ldapProtocol', 3);
         $object->_setProperty('ldapPort', (int)$row['ldap_port']);
         $object->_setProperty('ldapTls', (bool)$row['ldap_tls']);
+        $object->_setProperty('ldapTlsReqcert', (bool)$row['ldap_tls_reqcert']);
         $object->_setProperty('ldapSsl', (bool)$row['ldap_ssl']);
         $object->_setProperty('groupMembership', (int)$row['group_membership']);
     }


### PR DESCRIPTION
I just tried to update this extension on my installation from 3.3.1 to 3.5.1. Afterwards, I received the following error when trying to log in to the backend, even as a non-ldap user (`admin`):

> Core: Exception handler (WEB): Uncaught TYPO3 Exception: Return value of Causal\IgLdapSsoAuth\Domain\Model\Configuration::isLdapTlsReqcert() must be of the type bool, null returned | TypeError thrown in file /var/www/typo3/typo3conf/ext/ig_ldap_sso_auth/Classes/Domain/Model/Configuration.php in line 316. Requested URL: http://example.com/typo3/?loginProvider=1433416747

I managed to fix the bug for myself at least, but I'm not entirely sure on the specifics. It seems the initial value for the `$ldapTlsReqcert` field (`true`) is ignored, hence it needs to be set explicitly. Which is what I then did in `thawProperties()`. Since the initialization with `true` seems to be ignored, I removed it as well.
Apparently you guys don't all have this bug so maybe it is something specific to my PHP version.

I'm using TYPO3 v8.7.31 and PHP v7.3.14 (Debian).