### PR TITLE
[BUGFIX] Load all LDAP attributes when getGroupsProcessing is set

### DIFF
--- a/Classes/Library/Configuration.php
+++ b/Classes/Library/Configuration.php
@@ -425,7 +425,7 @@ class Configuration
             && (
                 is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['extraDataProcessing'])
                 || is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['extraMergeField'])
-                || is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['getGroupProcessing'])
+                || is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['getGroupsProcessing'])
             );
 
         if (is_array($mapping) && !$extended) {


### PR DESCRIPTION
There is just a simple `s` missing in the code, so all LDAP attributes are loaded when the given hook is configured.

The hook used in `Library/Authentication.php` is configured as following:

```
$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['getGroupsProcessing']
```

I think it is better to just add the `s` as suggested in this PR instead of removing the `s` in the Hook declaration, which would break existing implementations.