### PR TITLE
[Bugfix] Remove getLanguageService from Import Task for TYPO3 10 compatibility

### DIFF
--- a/Classes/Task/ImportUsers.php
+++ b/Classes/Task/ImportUsers.php
@@ -352,16 +352,6 @@ class ImportUsers extends \TYPO3\CMS\Scheduler\Task\AbstractTask
     }
 
     /**
-     * Returns the LanguageService.
-     *
-     * @return \TYPO3\CMS\Lang\LanguageService
-     */
-    protected function getLanguageService()
-    {
-        return $GLOBALS['LANG'];
-    }
-
-    /**
      * Returns a logger.
      *
      * @return \TYPO3\CMS\Core\Log\Logger


### PR DESCRIPTION
Function declaration is not valid any more. Using default function from AbstractTask instead.