### PR TITLE
[BUGFIX] Rename method getLanguageService

### DIFF
--- a/Classes/Library/Authentication.php
+++ b/Classes/Library/Authentication.php
@@ -435,7 +435,7 @@ class Authentication
         if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['getGroupsProcessing'])) {
             foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['getGroupsProcessing'] as $className) {
                 /** @var $postProcessor \Causal\IgLdapSsoAuth\Utility\GetGroupsProcessorInterface */
-                $postProcessor = GeneralUtility::getUserObj($className);
+                $postProcessor = GeneralUtility::makeInstance($className);
                 if ($postProcessor instanceof \Causal\IgLdapSsoAuth\Utility\GetGroupsProcessorInterface) {
                     $postProcessor->getUserGroups($groupTable, $ldapUser, $typo3_groups);
                 } else {
@@ -754,7 +754,7 @@ class Authentication
                         !empty($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['extraMergeField'][$hookName])
                     ) {
 
-                        $_procObj = GeneralUtility::getUserObj($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['extraMergeField'][$hookName]);
+                        $_procObj = GeneralUtility::makeInstance($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['extraMergeField'][$hookName]);
                         if (!is_callable([$_procObj, 'extraMerge'])) {
                             throw new \UnexpectedValueException(sprintf('Custom marker hook "%s" does not have a method "extraMerge"', $hookName), 1430140817);
                         }

--- a/Classes/Task/ImportUsers.php
+++ b/Classes/Task/ImportUsers.php
@@ -214,7 +214,7 @@ class ImportUsers extends \TYPO3\CMS\Scheduler\Task\AbstractTask
      */
     public function getAdditionalInformation()
     {
-        $languageService = $this->getLanguageService();
+        $languageService = $this->getLanguageServiceForLdap();
 
         if (empty($this->configuration)) {
             $configurationName = $languageService->sL('LLL:EXT:ig_ldap_sso_auth/Resources/Private/Language/locallang.xlf:task.import_users.field.configuration.all');
@@ -354,9 +354,9 @@ class ImportUsers extends \TYPO3\CMS\Scheduler\Task\AbstractTask
     /**
      * Returns the LanguageService.
      *
-     * @return \TYPO3\CMS\Lang\LanguageService
+     * @return \TYPO3\CMS\Lang\LanguageService|\TYPO3\CMS\Core\Localization\LanguageService
      */
-    protected function getLanguageService()
+    protected function getLanguageServiceForLdap()
     {
         return $GLOBALS['LANG'];
     }

--- a/Classes/Utility/LdapUtility.php
+++ b/Classes/Utility/LdapUtility.php
@@ -368,7 +368,7 @@ class LdapUtility
             if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['attributesProcessing'])) {
                 foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['attributesProcessing'] as $className) {
                     /** @var \Causal\IgLdapSsoAuth\Utility\AttributesProcessorInterface $postProcessor */
-                    $postProcessor = GeneralUtility::getUserObj($className);
+                    $postProcessor = GeneralUtility::makeInstance($className);
                     if ($postProcessor instanceof \Causal\IgLdapSsoAuth\Utility\AttributesProcessorInterface) {
                         $postProcessor->processAttributes($this->connection, $entry, $attributes);
                     } else {

--- a/Classes/Utility/UserImportUtility.php
+++ b/Classes/Utility/UserImportUtility.php
@@ -258,7 +258,7 @@ class UserImportUtility
             if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['extraDataProcessing'])) {
                 foreach ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['extraDataProcessing'] as $className) {
                     /** @var \Causal\IgLdapSsoAuth\Utility\ExtraDataProcessorInterface $postProcessor */
-                    $postProcessor = GeneralUtility::getUserObj($className);
+                    $postProcessor = GeneralUtility::makeInstance($className);
                     if ($postProcessor instanceof \Causal\IgLdapSsoAuth\Utility\ExtraDataProcessorInterface) {
                         $postProcessor->processExtraData($this->userTable, $user);
                     } else {


### PR DESCRIPTION
The method `getLanguageService` is not compatible with the method
signature in AbstractTask.

Solution is to rename the function. This ensures backwards compatibility
with TYPO3 versions 8 and 9.

Fixes: #101