### PR TITLE
[BUGFIX] Remove deprecated approach to init TSFE

### DIFF
--- a/Classes/Library/Authentication.php
+++ b/Classes/Library/Authentication.php
@@ -686,13 +686,30 @@ class Authentication
             $backupTSFE = $GLOBALS['TSFE'];
 
             // Advanced stdWrap methods require a valid $GLOBALS['TSFE'] => create the most lightweight one
+            // Use SiteFinder to get a Site object for the current page tree
+            $siteFinder = GeneralUtility::makeInstance(
+                \TYPO3\CMS\Core\Site\SiteFinder::class
+            );
+            $currentSite = $siteFinder->getSiteByPageId($typo3['uid']);
+
+            // Context is a singleton, so we can get the current Context by instantiation
+            $currentContext = GeneralUtility::makeInstance(
+                \TYPO3\CMS\Core\Context\Context::class
+            );
+
+            // Use Site & Context to instatiate TSFE properly for Typo3 v10+
             $GLOBALS['TSFE'] = GeneralUtility::makeInstance(
                 \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController::class,
-                $GLOBALS['TYPO3_CONF_VARS'],
-                0,
-                ''
+                $currentContext,
+                $currentSite,
+                $currentSite->getDefaultLanguage()
             );
-            $GLOBALS['TSFE']->initTemplate();
+
+            // initTemplate() has been removed. The deprecation notice suggest setting the property directly by yourself
+            $GLOBALS['TSFE']->tmpl = GeneralUtility::makeInstance(
+                \TYPO3\CMS\Core\TypoScript\TemplateService::class,
+                $currentContext
+            );
             $GLOBALS['TSFE']->renderCharset = 'utf-8';
 
             /** @var $contentObj \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer */

--- a/Classes/Library/Authentication.php
+++ b/Classes/Library/Authentication.php
@@ -686,30 +686,45 @@ class Authentication
             $backupTSFE = $GLOBALS['TSFE'];
 
             // Advanced stdWrap methods require a valid $GLOBALS['TSFE'] => create the most lightweight one
-            // Use SiteFinder to get a Site object for the current page tree
-            $siteFinder = GeneralUtility::makeInstance(
-                \TYPO3\CMS\Core\Site\SiteFinder::class
-            );
-            $currentSite = $siteFinder->getSiteByPageId($typo3['uid']);
+            $typo3Branch = class_exists(\TYPO3\CMS\Core\Information\Typo3Version::class)
+                ? (new \TYPO3\CMS\Core\Information\Typo3Version())->getBranch()
+                : TYPO3_branch;
+            if (version_compare($typo3Branch, '10.0', '<')) {
+                // Keep the old approach to init TSFE before Typo3 v10
+                $GLOBALS['TSFE'] = GeneralUtility::makeInstance(
+                    \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController::class,
+                    $GLOBALS['TYPO3_CONF_VARS'],
+                    0,
+                    ''
+                );
+                $GLOBALS['TSFE']->initTemplate();
+            } else {
+                // Use a modern approach to init TSFE on Typo3 v10+
+                // Use SiteFinder to get a Site object for the current page tree
+                $siteFinder = GeneralUtility::makeInstance(
+                    \TYPO3\CMS\Core\Site\SiteFinder::class
+                );
+                $currentSite = $siteFinder->getSiteByPageId($typo3['uid']);
 
-            // Context is a singleton, so we can get the current Context by instantiation
-            $currentContext = GeneralUtility::makeInstance(
-                \TYPO3\CMS\Core\Context\Context::class
-            );
+                // Context is a singleton, so we can get the current Context by instantiation
+                $currentContext = GeneralUtility::makeInstance(
+                    \TYPO3\CMS\Core\Context\Context::class
+                );
 
-            // Use Site & Context to instatiate TSFE properly for Typo3 v10+
-            $GLOBALS['TSFE'] = GeneralUtility::makeInstance(
-                \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController::class,
-                $currentContext,
-                $currentSite,
-                $currentSite->getDefaultLanguage()
-            );
+                // Use Site & Context to instantiate TSFE properly for Typo3 v10+
+                $GLOBALS['TSFE'] = GeneralUtility::makeInstance(
+                    \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController::class,
+                    $currentContext,
+                    $currentSite,
+                    $currentSite->getDefaultLanguage()
+                );
 
-            // initTemplate() has been removed. The deprecation notice suggest setting the property directly by yourself
-            $GLOBALS['TSFE']->tmpl = GeneralUtility::makeInstance(
-                \TYPO3\CMS\Core\TypoScript\TemplateService::class,
-                $currentContext
-            );
+                // initTemplate() has been removed. The deprecation notice suggest setting the property directly by yourself
+                $GLOBALS['TSFE']->tmpl = GeneralUtility::makeInstance(
+                    \TYPO3\CMS\Core\TypoScript\TemplateService::class,
+                    $currentContext
+                );
+            }
             $GLOBALS['TSFE']->renderCharset = 'utf-8';
 
             /** @var $contentObj \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer */


### PR DESCRIPTION
Typo3 v10 changed how TSFE is constructed. makeInstance() has been updated and all necessary arguments have been fetched with core api.
Also, $GLOBALS['TSFE']->initTemplate() has been removed. It has been replaced with the suggested replacement approach.

I came across this error in a new Typo3 v10 installation with LDAP frontend login (LDAP backend login worked fine):
> #1561583122 InvalidArgumentException
> TypoScriptFrontendController must be constructed with a valid Site object or a resolved site in the current request as fallback. None given.

This traced to the TSFE instantiation around "ext/ig_ldap_sso_auth/Classes/Library/Authentication.php line 694" which seemed to be outdated.

I hope you can use this for the next release, thank you for your time and effort.