### PR TITLE
[BUGFIX] Convert tstamp to int for MariaDB

### DIFF
--- a/Classes/Domain/Repository/Typo3UserRepository.php
+++ b/Classes/Domain/Repository/Typo3UserRepository.php
@@ -173,7 +173,8 @@ class Typo3UserRepository
 
         $tableConnection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable($table);
-
+        //tstamp needs to be int. If it's empty it's transferred as ""
+        $cleanData['tstamp'] = intval($data['tstamp']);
         $tableConnection->insert(
             $table,
             $data
@@ -221,6 +222,8 @@ class Typo3UserRepository
 
         $cleanData = $data;
         unset($cleanData['__extraData']);
+        //tstamp needs to be int. If it's empty it's transferred as ""
+        $cleanData['tstamp'] = intval($cleanData['tstamp']);
 
         $affectedRows = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable($table)


### PR DESCRIPTION
This is a bugfix when using MariaDB (v 10.2.31). 
Whenever users tried to log in or when I add a user, I got this error

` Core: Exception handler (WEB): Uncaught TYPO3 Exception: An exception occurred while executing 'UPDATE 'be_users' SET 'uid' = ?, 'pid' = ?, 'tstamp' = ?, 'username' = ?, 'description' = ?, 'avatar' = ?, 'password' = ?, 'admin' = ?, 'usergroup' = ?, 'disable' = ?, 'starttime' = ?, 'endtime' = ?, 'lang' = ?, 'email' = ?, 'db_mountpoints' = ?, 'options' = ?, 'crdate' = ?, 'cruser_id' = ?, 'realName' = ?, 'userMods' = ?, 'allowed_languages' = ?, 'uc' = ?, 'file_mountpoints' = ?, 'file_permissions' = ?, 'workspace_perms' = ?, 'lockToDomain' = ?, 'disableIPlock' = ?, 'deleted' = ?, 'TSconfig' = ?, 'lastlogin' = ?, 'createdByAction' = ?, 'usergroup_cached_list' = ?, 'workspace_id' = ?, 'category_perms' = ?, 'tx_news_categorymounts' = ?, 'tx_igldapssoauth_dn' = ?, 'tx_igldapssoauth_id' = ?, 'password_reset_token' = ? WHERE 'uid' = ?' with params [123, 0, "", (...) ]: Incorrect integer value: '' for column 'website_name'.'be_users'.'tstamp' at row 1 | Doctrine\DBAL\Exception\DriverException thrown in file /var/www/website_name/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php in line 110. Requested URL: https://website_name/typo3/?loginProvider=1234567`

In both cases tstamp was given as "" and transferred as empty string.
`(...) with params [123, 0, "", "username", null, ...]`

MariaDB seems to be stricter than MySQL and the above error occurs.

This bugfix converts tstamp to int in Classes/Domain/Repository/Typo3UserRepository.php -> add and update
