### PR TITLE
[SECURITY] Escape username for ldap filter

### DIFF
--- a/Classes/Library/Ldap.php
+++ b/Classes/Library/Ldap.php
@@ -132,7 +132,7 @@ class Ldap
     public function validateUser($username = null, $password = null, $baseDn = null, $filter = null)
     {
         // If user found on ldap server.
-        if ($this->ldapUtility->search($baseDn, str_replace('{USERNAME}', $username, $filter), ['dn'])) {
+        if ($this->ldapUtility->search($baseDn, str_replace('{USERNAME}', ldap_escape($username, '', LDAP_ESCAPE_FILTER), $filter), ['dn'])) {
 
             // Validate with password.
             if ($password !== null) {


### PR DESCRIPTION
Currently it is possible to enter LDAP wildcards/filters in the username login field and they don't get escaped. E.g. if the username is something like `my.name@company.com` you could just enter `*name*` and if LDAP returns the user as the first result you can successfully login (provided the password is correct). I think this is an security issue because there could be more elaborate things possible but i am not sure.

To fix this i added a `ldap_escape()` to the corresponding LDAP search. This escapes the username so it can be used in a filter without changing the intent of the filter itself. I'm not sure if there are other places this (`LDAP_ESCAPE_FILTER`) or an DN escape (`LDAP_ESCAPE_DN`) should be done.