### PR TITLE
Fix ldap entries validation

### DIFF
--- a/Classes/Utility/LdapUtility.php
+++ b/Classes/Utility/LdapUtility.php
@@ -334,8 +334,9 @@ class LdapUtility
                     );
             } else {
                 $ldapControls = ldap_read($this->connection, '', '(objectClass=*)', ['supportedControl']);
-                if (in_array(LDAP_CONTROL_PAGEDRESULTS, ldap_get_entries($this->connection, $ldapControls)[0]['supportedcontrol'])) {
-                    $this->hasPagination = true;
+                $ldapEntries = ldap_get_entries($this->connection, $ldapControls);
+                if (isset($ldapEntries[0]['supportedcontrol']) && in_array(LDAP_CONTROL_PAGEDRESULTS, $ldapEntries[0]['supportedcontrol'])) {
+                  $this->hasPagination = true;
                 }
                 $controls = [['oid' => LDAP_CONTROL_PAGEDRESULTS, 'value' => ['size' => static::MAX_ENTRIES, 'cookie' => $this->paginationCookie]]];
             }

--- a/Classes/Utility/LdapUtility.php
+++ b/Classes/Utility/LdapUtility.php
@@ -338,6 +338,7 @@ class LdapUtility
                 if (isset($ldapEntries[0]['supportedcontrol']) && in_array(LDAP_CONTROL_PAGEDRESULTS, $ldapEntries[0]['supportedcontrol'])) {
                   $this->hasPagination = true;
                 }
+
                 $controls = [['oid' => LDAP_CONTROL_PAGEDRESULTS, 'value' => ['size' => static::MAX_ENTRIES, 'cookie' => $this->paginationCookie]]];
             }
 


### PR DESCRIPTION
If the Ldap controls are not set in the ldap directory, it causes an error because the controls array is not set. 