### PR TITLE
[DOCS] Improve documentation for the dedicated log file example

### DIFF
--- a/Documentation/AdministratorManual/Logging.rst
+++ b/Documentation/AdministratorManual/Logging.rst
@@ -30,7 +30,7 @@ the system log, you may add following configuration to
 	$GLOBALS['TYPO3_CONF_VARS']['LOG']['Causal']['IgLdapSsoAuth']['writerConfiguration'] = [
 	    \TYPO3\CMS\Core\Log\LogLevel::DEBUG => [
 	        \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
-	            'logFile' => Environment::getVarPath() . '/log/ldap.log'
+	            'logFile' => \TYPO3\CMS\Core\Core\Environment::getVarPath() . '/log/ldap.log'
 	        ],
 	    ],
 


### PR DESCRIPTION
The change adapts the code sample for setting up a dedicated log file for LDAP:
- https://docs.typo3.org/p/causal/ig_ldap_sso_auth/main/en-us/AdministratorManual/Logging.html#dedicated-log-file-for-ldap

The standard TYPO3 namespace "\TYPO3\CMS\Core\Core\" is missing which can cause several issues.