### PR TITLE
Fix deprecation in PHP 8.1: selectFromMembership function params

### DIFF
--- a/Classes/Library/Authentication.php
+++ b/Classes/Library/Authentication.php
@@ -474,9 +474,9 @@ class Authentication
             // Get LDAP groups from membership attribute
             if ($membership = LdapGroup::getMembership($ldapUser, static::$config['users']['mapping'])) {
                 $ldapGroups = LdapGroup::selectFromMembership(
-                    $membership,
                     static::$config['groups']['basedn'],
                     static::$config['groups']['filter'],
+                    $membership,
                     $ldapGroupAttributes,
                     // If groups should not get synchronized, there is no need to actively check them
                     // against the LDAP server, simply accept every groups from $membership matching


### PR DESCRIPTION
The following deprecation notice gets added to the deprecation log:

Wed, 15 Feb 2023 08:27:07 +0100 [NOTICE] request="7a6c1bb9d9442" component="TYPO3.CMS.deprecations": Core: Error handler (BE): PHP Runtime Deprecation Notice: Optional parameter $membership declared before required parameter $filter is implicitly treated as a required parameter in (...)/typo3conf/ext/ig_ldap_sso_auth/Classes/Library/LdapGroup.php line 41

The order of the selectFromMembership function parameters inside LdapGroup.php could be re-organized so as to avoid the above notice, by moving the optional parameter $membership after all the required parameters.