### PR TITLE
[BUGFIX] Provide table name to lastInsertId()

### DIFF
--- a/Classes/Domain/Repository/Typo3GroupRepository.php
+++ b/Classes/Domain/Repository/Typo3GroupRepository.php
@@ -135,7 +135,7 @@ class Typo3GroupRepository
             $table,
             $data
         );
-        $uid = $tableConnection->lastInsertId();
+        $uid = $tableConnection->lastInsertId($table);
 
         $newRow = $tableConnection
             ->select(

--- a/Classes/Domain/Repository/Typo3UserRepository.php
+++ b/Classes/Domain/Repository/Typo3UserRepository.php
@@ -186,7 +186,7 @@ class Typo3UserRepository
             $data
         );
 
-        $uid = $tableConnection->lastInsertId();
+        $uid = $tableConnection->lastInsertId($table);
 
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable($table);


### PR DESCRIPTION
Analogue to the 7 year old issue in the TYPO3 core: https://forge.typo3.org/issues/77833

Databases like Oracle or PostgreSQL use sequences to ensure unique ids for columns. The need the information which sequence to check to return the last insert id.

Without this, when using e.g. PostgreSQL as database, importing users and groups throws an exception
> "SQLSTATE[42P01]: Undefined table: 7 ERROR:  relation "uid_seq" does not exist. CONTEXT:  unnamed portal parameter $1 = '...'"