### PR TITLE
Fix return in ImportUsers::setConfiguration

### DIFF
--- a/Classes/Task/ImportUsers.php
+++ b/Classes/Task/ImportUsers.php
@@ -305,6 +305,7 @@ class ImportUsers extends \TYPO3\CMS\Scheduler\Task\AbstractTask
     public function setConfiguration(int $configuration): self
     {
         $this->configuration = $configuration;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
When creating a scheduler task, an exception occurrs because the return in ImportUsers::setConfiguration is missing