### PR TITLE
[BUGFIX] restore functionality for Active Directory Servers

### DIFF
--- a/Classes/Library/Ldap.php
+++ b/Classes/Library/Ldap.php
@@ -87,7 +87,7 @@ class Ldap
             $config['port'],
             3,
             $config['charset'],
-            $config['server'],
+            Configuration::getServerType($config['server']),
             $config['tls'],
             $config['ssl'],
             $config['tlsReqcert']


### PR DESCRIPTION
this commit reverts 6a4c5367f601a95db73567de5d9962cfad69c7d5

refs #207 
https://github.com/xperseguers/t3ext-ig_ldap_sso_auth/issues/207