### PR TITLE
Feature: Process Typoscript for groups before comparing titles

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -538,7 +538,8 @@ class ModuleController extends ActionController
             $typo3Groups = Authentication::getOrCreateTypo3Groups(
                 [$ldapGroup],
                 $table,
-                $pid
+                $pid,
+                $config['groups']['mapping']
             );
 
             // Merge LDAP and TYPO3 information
@@ -633,7 +634,8 @@ class ModuleController extends ActionController
                     $typo3Groups = Authentication::getOrCreateTypo3Groups(
                         $ldapGroups,
                         $table,
-                        $pid
+                        $pid,
+                        $config['groups']['mapping']
                     );
 
                     foreach ($ldapGroups as $index => $ldapGroup) {
@@ -759,7 +761,8 @@ class ModuleController extends ActionController
         $typo3Groups = Authentication::getOrCreateTypo3Groups(
             $ldapGroups,
             $table,
-            $typo3GroupPid
+            $typo3GroupPid,
+            $config['groups']['mapping']
         );
 
         foreach ($ldapGroups as $index => $ldapGroup) {

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -304,7 +304,18 @@ class ModuleController extends ActionController
         $pageRenderer->loadRequireJsModule('TYPO3/CMS/IgLdapSsoAuth/Import');
 
         $groups = $this->getAvailableUserGroups($configuration, 'be');
-        $this->view->assign('groups', $groups);
+        $titles = [];
+        $uniqueGroups = array_filter($groups, function($group) use (&$titles) {
+            if (in_array($group['title'], $titles)) {
+                return false;
+            }
+            $titles[] = $group['title'];
+            return true;
+        });
+        usort($uniqueGroups, function($a, $b) {
+            return strnatcmp($a['title'], $b['title']);
+        });
+        $this->view->assign('groups', $uniqueGroups);
     }
 
     /**

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -544,7 +544,7 @@ class ModuleController extends ActionController
             // Merge LDAP and TYPO3 information
             $group = Authentication::merge($ldapGroup, $typo3Groups[0], $config['groups']['mapping']);
 
-            if ((int)$group['uid'] === 0) {
+            if (!isset($group['uid']) || (int)$group['uid'] === 0) {
                 $group = Typo3GroupRepository::add($table, $group);
             } else {
                 // Restore group that may have been previously deleted
@@ -552,7 +552,7 @@ class ModuleController extends ActionController
                 $success = Typo3GroupRepository::update($table, $group);
             }
 
-            if (!empty($config['groups']['mapping']['parentGroup'])) {
+            if (isset($config['groups']['mapping']['parentGroup'])) {
                 $fieldParent = $config['groups']['mapping']['parentGroup'];
                 if (preg_match("`<([^$]*)>`", $fieldParent, $attribute)) {
                     $fieldParent = $attribute[1];

--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -535,7 +535,7 @@ class ModuleController extends ActionController
 
             $pid = Configuration::getPid($config['groups']['mapping']);
             $table = $params['mode'] === 'be' ? 'be_groups' : 'fe_groups';
-            $typo3Groups = Authentication::getTypo3Groups(
+            $typo3Groups = Authentication::getOrCreateTypo3Groups(
                 [$ldapGroup],
                 $table,
                 $pid
@@ -630,7 +630,7 @@ class ModuleController extends ActionController
                     // Populate an array of TYPO3 group records corresponding to the LDAP groups
                     // If a given LDAP group has no associated group in TYPO3, a fresh record
                     // will be created so that $ldapGroups[i] <=> $typo3Groups[i]
-                    $typo3Groups = Authentication::getTypo3Groups(
+                    $typo3Groups = Authentication::getOrCreateTypo3Groups(
                         $ldapGroups,
                         $table,
                         $pid
@@ -756,7 +756,7 @@ class ModuleController extends ActionController
         // will be created so that $ldapGroups[i] <=> $typo3Groups[i]
         $typo3GroupPid = Configuration::getPid($config['groups']['mapping']);
         $table = ($mode === 'be') ? 'be_groups' : 'fe_groups';
-        $typo3Groups = Authentication::getTypo3Groups(
+        $typo3Groups = Authentication::getOrCreateTypo3Groups(
             $ldapGroups,
             $table,
             $typo3GroupPid

--- a/Classes/Library/Authentication.php
+++ b/Classes/Library/Authentication.php
@@ -193,7 +193,7 @@ class Authentication
         $typo3_users_pid = Configuration::getPid(static::$config['users']['mapping']);
 
         // Get TYPO3 user from username, DN and pid.
-        $typo3_user = static::getTypo3User($username, $userdn, $typo3_users_pid);
+        $typo3_user = static::getOrCreateTypo3User($username, $userdn, $typo3_users_pid);
         if ($typo3_user === null) {
             // Non-existing local users are not allowed to authenticate
             return false;
@@ -202,7 +202,7 @@ class Authentication
         // Get LDAP and TYPO3 user groups for user
         // First reset the LDAP groups
         static::$ldapGroups = null;
-        $typo3_groups = static::getUserGroups($ldapUser);
+        $typo3_groups = static::getOrCreateUserGroups($ldapUser);
         if ($typo3_groups === null) {
             // Required LDAP groups are missing
             static::$lastAuthenticationDiagnostic = 'Missing required LDAP groups.';
@@ -333,7 +333,7 @@ class Authentication
      * @return array|null Array of groups or null if required LDAP groups are missing
      * @throws \Causal\IgLdapSsoAuth\Exception\InvalidUserGroupTableException
      */
-    public static function getUserGroups(array $ldapUser, array $configuration = null, string $groupTable = ''): ?array
+    public static function getOrCreateUserGroups(array $ldapUser, array $configuration = null, string $groupTable = ''): ?array
     {
         if ($configuration === null) {
             $configuration = static::$config;
@@ -359,7 +359,7 @@ class Authentication
             // Get pid from group mapping
             $typo3GroupPid = Configuration::getPid($configuration['groups']['mapping']);
 
-            $typo3GroupsTemp = static::getTypo3Groups(
+            $typo3GroupsTemp = static::getOrCreateTypo3Groups(
                 $ldapGroups,
                 $groupTable,
                 $typo3GroupPid,
@@ -521,7 +521,7 @@ class Authentication
      * @param int|null $pid
      * @return array|null
      */
-    protected static function getTypo3User(string $username, string $userDn, ?int $pid = null): ?array
+    protected static function getOrCreateTypo3User(string $username, string $userDn, ?int $pid = null): ?array
     {
         $user = null;
 
@@ -574,7 +574,7 @@ class Authentication
      * @param array $mapping
      * @return array
      */
-    public static function getTypo3Groups(
+    public static function getOrCreateTypo3Groups(
         array $ldapGroups = [],
         ?string $table = null,
         ?int $pid = null,
@@ -621,7 +621,7 @@ class Authentication
      * @param int|null $pid
      * @return array
      */
-    public static function getTypo3Users(
+    public static function getOrCreateTypo3Users(
         array $ldapUsers = [],
         array $mapping = [],
         ?string $table = null,

--- a/Classes/Library/Configuration.php
+++ b/Classes/Library/Configuration.php
@@ -43,11 +43,12 @@ class Configuration
      */
     protected static $configuration;
 
-    protected static $mode = null;
+    protected static $mode = 'be';
     protected static $be = [];
     protected static $fe = [];
     protected static $ldap = [];
     protected static $domains = [];
+    protected static $initialized = false;
 
     /**
      * Initializes the configuration class.
@@ -140,6 +141,8 @@ class Configuration
         static::$ldap['ssl'] = $configuration->isLdapSsl();
         static::$ldap['binddn'] = $configuration->getLdapBindDn();
         static::$ldap['password'] = $configuration->getLdapPassword();
+
+        static::$initialized = true;
     }
 
     /**
@@ -149,7 +152,7 @@ class Configuration
      */
     public static function isInitialized(): bool
     {
-        return static::$mode !== null;
+        return static::$initialized !== false;
     }
 
     /**

--- a/Classes/Library/Configuration.php
+++ b/Classes/Library/Configuration.php
@@ -43,7 +43,7 @@ class Configuration
      */
     protected static $configuration;
 
-    protected static $mode = 'be';
+    protected static $mode = null;
     protected static $be = [];
     protected static $fe = [];
     protected static $ldap = [];

--- a/Classes/Library/Configuration.php
+++ b/Classes/Library/Configuration.php
@@ -209,11 +209,19 @@ class Configuration
         // Default fields : title, tx_igldapssoauth_dn
 
         $groupMapping = static::parseMapping($mapping);
-        if (!isset($groupMapping['title'])) {
+        if (
+          !isset($groupMapping['title'])
+          && !isset($groupMapping['title.'])
+        ) {
             $groupMapping['title'] = '<dn>';
         }
-        $groupMapping['tx_igldapssoauth_dn'] = '<dn>';
 
+        if (
+          !isset($groupMapping['tx_igldapssoauth_dn'])
+          && !isset($groupMapping['tx_igldapssoauth_dn.'])
+        ) {
+          $groupMapping['tx_igldapssoauth_dn'] = '<dn>';
+        }
         return $groupMapping;
     }
 

--- a/Classes/Task/ImportUsers.php
+++ b/Classes/Task/ImportUsers.php
@@ -305,6 +305,7 @@ class ImportUsers extends \TYPO3\CMS\Scheduler\Task\AbstractTask
     public function setConfiguration(int $configuration): self
     {
         $this->configuration = $configuration;
+        return $this;
     }
 
     /**

--- a/Classes/Utility/UserImportUtility.php
+++ b/Classes/Utility/UserImportUtility.php
@@ -191,7 +191,7 @@ class UserImportUtility
         // If a given LDAP user has no associated user in TYPO3, a fresh record
         // will be created so that $ldapUsers[i] <=> $typo3Users[i]
         $typo3UserPid = Configuration::getPid($this->configuration['users']['mapping']);
-        $typo3Users = Authentication::getTypo3Users(
+        $typo3Users = Authentication::getOrCreateTypo3Users(
             $ldapUsers,
             $this->configuration['users']['mapping'],
             $this->userTable,
@@ -217,7 +217,7 @@ class UserImportUtility
             unset($user['__extraData']);
         }
 
-        $typo3Groups = Authentication::getUserGroups($ldapUser, $this->configuration, $this->groupTable);
+        $typo3Groups = Authentication::getOrCreateUserGroups($ldapUser, $this->configuration, $this->groupTable);
         if ($typo3Groups === null) {
             // Required LDAP groups are missing: quit!
             return $user;

--- a/Classes/ViewHelpers/ConfigurationTableViewHelper.php
+++ b/Classes/ViewHelpers/ConfigurationTableViewHelper.php
@@ -165,7 +165,7 @@ class ConfigurationTableViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abs
             $value = $iconFactory->getIcon($icon, \TYPO3\CMS\Core\Imaging\Icon::SIZE_SMALL, $overlay)->render() . ' ' . htmlspecialchars($value->getTitle());
             $value = str_replace('<img src=', '<img title="' . htmlspecialchars($options['title']) . '" src=', $value);
         } else {
-            $value = htmlspecialchars($value);
+            $value = htmlspecialchars((string)$value);
         }
 
         return sprintf('<td class="%s">%s</td>', $class, $value);


### PR DESCRIPTION
We have a fairly complex ldap structure. Groups and Users are under different trees and group membership is done by creating a user alias below the corresponding group structure.

I love the flexibility of this plugin to process typoscript to map the ldap data, unfortunately it was not enough as the mapping was taking place after the check if the group is already existing and new typo3 groups were always created. In our case the group name has to be extracted from the users alias DN.