### PR TITLE
Fix for "Incorrect integer value" on control TCA disabled property

### DIFF
--- a/Classes/Domain/Repository/Typo3UserRepository.php
+++ b/Classes/Domain/Repository/Typo3UserRepository.php
@@ -179,8 +179,10 @@ class Typo3UserRepository
 
         $tableConnection = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable($table);
-        // tstamp needs to be int. If it's empty it's transferred as ""
+        // tstamp and disable needs to be int. If it's empty it's transferred as ""
         $data['tstamp'] = (int)$data['tstamp'];
+        $data['disable'] = (int)$data['disable'];
+
         $tableConnection->insert(
             $table,
             $data
@@ -228,8 +230,9 @@ class Typo3UserRepository
 
         $cleanData = $data;
         unset($cleanData['__extraData']);
-        // tstamp needs to be int. If it's empty it's transferred as ""
+        // tstamp and disable needs to be int. If it's empty it's transferred as ""
         $cleanData['tstamp'] = (int)$cleanData['tstamp'];
+        $cleanData['disable'] = (int)$cleanData['disable'];
 
         $affectedRows = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable($table)


### PR DESCRIPTION
We have a scenario where disabled users are imported without previously existing.

This produces an `Incorrect integer value: '' for column be_users.disable` SQL error on MariaDB, as thje given value on the raw SQL is simply `""` with the following truncated stacktrace:

```
#3 /var/www/html/public/typo3/sysext/core/Classes/Database/Connection.php(218): Doctrine\\DBAL\\Connection->insert('`be_users`', Array, Array)
#4 /var/www/html/public/typo3conf/ext/ig_ldap_sso_auth/Classes/Domain/Repository/Typo3UserRepository.php(179): TYPO3\\CMS\\Core\\Database\\Connection->insert('be_users', Array)
#5 /var/www/html/public/typo3conf/ext/ig_ldap_sso_auth/Classes/Utility/UserImportUtility.php(228): Causal\\IgLdapSsoAuth\\Domain\\Repository\\Typo3UserRepository::add('be_users', Array)
#6 /var/www/html/public/typo3conf/ext/ig_ldap_sso_auth/Classes/Task/ImportUsers.php(193): Causal\\IgLdapSsoAuth\\Utility\\UserImportUtility->import(Array, Array, 'nothing')
#7 /var/www/html/public/typo3/sysext/scheduler/Classes/Scheduler.php(192): Causal\\IgLdapSsoAuth\\Task\\ImportUsers->execute()
```

This fix forces the type to ensure the correct typing of the injected value according to the [TYPO3 default TCA type](https://github.com/TYPO3/typo3/blob/11.5/typo3/sysext/core/Classes/Database/Schema/DefaultTcaSchema.php#L167).