### PR TITLE
[BUGFIX] Disable password hashing from LDAP configuration

### DIFF
--- a/Configuration/TCA/tx_igldapssoauth_config.php
+++ b/Configuration/TCA/tx_igldapssoauth_config.php
@@ -185,6 +185,7 @@ return [
             'config' => $typo3Version >= 12
                 ? [
                     'type' => 'password',
+                    'hashed' => false,
                 ]
                 : [
                     'type' => 'input',


### PR DESCRIPTION
Avoid password hashing on `tx_igldapssoauth_config` record update.