### PR TITLE
[FEATURE] Add network timeout option for LDAP

### DIFF
--- a/Classes/Domain/Model/Configuration.php
+++ b/Classes/Domain/Model/Configuration.php
@@ -56,6 +56,8 @@ class Configuration
 
     protected bool $ldapSsl = false;
 
+    protected int $ldapTimeout = 0;
+
     protected string $ldapBindDn = '';
 
     protected string $ldapPassword = '';
@@ -206,6 +208,16 @@ class Configuration
     public function isLdapSsl(): bool
     {
         return $this->ldapSsl;
+    }
+
+    public function getLdapTimeout(): int
+    {
+        return $this->ldapTimeout;
+    }
+
+    public function setLdapTimeout(int $ldapTimeout): void
+    {
+        $this->ldapTimeout = $ldapTimeout;
     }
 
     /**

--- a/Classes/Domain/Repository/ConfigurationRepository.php
+++ b/Classes/Domain/Repository/ConfigurationRepository.php
@@ -173,6 +173,7 @@ class ConfigurationRepository
             'sites' => 'sites',
             'ldap_charset' => 'ldapCharset',
             'ldap_host' => 'ldapHost',
+            'ldap_timeout' => 'ldapTimeout',
             'ldap_binddn' => 'ldapBindDn',
             'ldap_password' => 'ldapPassword',
             'be_users_basedn' => 'backendUsersBaseDn',

--- a/Classes/Library/Configuration.php
+++ b/Classes/Library/Configuration.php
@@ -151,6 +151,7 @@ class Configuration
         static::$ldap['ssl'] = $configuration->isLdapSsl();
         static::$ldap['binddn'] = $configuration->getLdapBindDn();
         static::$ldap['password'] = $configuration->getLdapPassword();
+        static::$ldap['timeout'] = $configuration->getLdapTimeout();
     }
 
     /**

--- a/Classes/Library/Ldap.php
+++ b/Classes/Library/Ldap.php
@@ -87,6 +87,7 @@ class Ldap
             'tls' => $config['tls'],
             'tlsReqcert' => $config['tlsReqcert'],
             'ssl' => $config['ssl'],
+            'timeout' => $config['timeout'],
         ];
         // Connect to ldap server.
         if (!$this->ldapUtility->connect(
@@ -97,7 +98,8 @@ class Ldap
             Configuration::getServerType((int)$config['server']),
             (bool)$config['tls'],
             (bool)$config['ssl'],
-            (bool)$config['tlsReqcert']
+            (bool)$config['tlsReqcert'],
+            (int)$config['timeout'],
         )) {
             static::getLogger()->error('Cannot connect', $debugConfiguration);
             return false;

--- a/Classes/Utility/LdapUtility.php
+++ b/Classes/Utility/LdapUtility.php
@@ -125,6 +125,7 @@ class LdapUtility
      * @param bool $tls
      * @param bool $ssl
      * @param bool $tlsReqcert
+     * @param int $timeout
      * @return bool true if connection succeeded.
      * @throws UnresolvedPhpDependencyException when LDAP extension for PHP is not available
      */
@@ -136,7 +137,8 @@ class LdapUtility
         string $serverType = 'OpenLDAP',
         bool $tls = false,
         bool $ssl = false,
-        bool $tlsReqcert = false
+        bool $tlsReqcert = false,
+        int $timeout = 0
     ): bool
     {
         if ($tlsReqcert === false) {
@@ -152,6 +154,11 @@ class LdapUtility
         $this->status['connect']['host'] = $host;
         $this->status['connect']['port'] = $port;
         $this->serverType = $serverType;
+
+        // Set custom network ldapTimeout
+        if ($timeout) {
+            @ldap_set_option(null, LDAP_OPT_NETWORK_TIMEOUT, $timeout);
+        }
 
         if ($ssl) {
             $this->status['option']['ssl'] = 'Enable';

--- a/Configuration/TCA/tx_igldapssoauth_config.php
+++ b/Configuration/TCA/tx_igldapssoauth_config.php
@@ -39,7 +39,7 @@ return [
     ],
     'palettes' => [
         'connection' => [
-            'showitem' => 'ldap_host, --linebreak--, ldap_port, --linebreak--, ldap_tls, ldap_tls_reqcert, ldap_ssl',
+            'showitem' => 'ldap_host, --linebreak--, ldap_port, --linebreak--, ldap_timeout, --linebreak--, ldap_tls, ldap_tls_reqcert, ldap_ssl',
         ],
     ],
     'columns' => [
@@ -167,6 +167,16 @@ return [
             'config' => [
                 'type' => 'check',
                 'renderType' => 'checkboxToggle',
+            ],
+        ],
+        'ldap_timeout' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:ig_ldap_sso_auth/Resources/Private/Language/locallang_db.xlf:tx_igldapssoauth_config.ldap_timeout',
+            'config' => [
+                'type' => 'input',
+                'size' => 4,
+                'eval' => 'int',
+                'default' => 0,
             ],
         ],
         'ldap_binddn' => [

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -100,6 +100,9 @@
 			<trans-unit id="tx_igldapssoauth_config.ldap_ssl">
 				<source>Use SSL</source>
 			</trans-unit>
+			<trans-unit id="tx_igldapssoauth_config.ldap_timeout">
+				<source>Custom network timeout (in seconds)</source>
+			</trans-unit>
 			<trans-unit id="tx_igldapssoauth_config.ldap_binddn">
 				<source>Bind DN</source>
 			</trans-unit>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -19,6 +19,7 @@ CREATE TABLE tx_igldapssoauth_config (
 	ldap_tls tinyint(4) DEFAULT '0' NOT NULL,
 	ldap_tls_reqcert  tinyint(4) DEFAULT '1' NOT NULL,
 	ldap_ssl tinyint(4) DEFAULT '0' NOT NULL,
+	ldap_timeout int(11) DEFAULT '0' NOT NULL,
 	ldap_binddn tinytext NOT NULL,
 	ldap_password varchar(255) DEFAULT '' NOT NULL,
 	group_membership tinyint(4) DEFAULT '0' NOT NULL,


### PR DESCRIPTION
Add the ldap_timeout field to configuration.
It will be used to set LDAP_OPT_NETWORK_TIMEOUT.

Resolves: #227