### PR TITLE
[TASK] $status must not be accessed before initialization

### DIFF
--- a/Classes/Utility/LdapUtility.php
+++ b/Classes/Utility/LdapUtility.php
@@ -87,7 +87,7 @@ class LdapUtility
      * LDAP server status
      * @var array
      */
-    protected array $status;
+    protected array $status = [];
 
     /**
      * 'OpenLDAP' OR 'Active Directory'


### PR DESCRIPTION
This PR Fixes the Issue:
```
Typed property Causal\IgLdapSsoAuth\Utility\LdapUtility::$status must not be accessed before initialization
in /var/www/html/typo3conf/ext/ig_ldap_sso_auth/Classes/Utility/LdapUtility.php line 520
```