### PR TITLE
[BUGFIX] Add missing dispatch of AttributesProcessingEvent in getFirstEntry() of LdapUtility class

### DIFF
--- a/Classes/Utility/LdapUtility.php
+++ b/Classes/Utility/LdapUtility.php
@@ -495,11 +495,10 @@ class LdapUtility
         $tempEntry = [];
         if (is_resource($this->firstResultEntry) || is_object($this->firstResultEntry) /* PHP 8.1 */) {
             $attributes = @ldap_get_attributes($this->connection, $this->firstResultEntry);
-            $entry = @ldap_first_entry($this->connection, $this->searchResult);
 
             $event = NotificationUtility::dispatch(new AttributesProcessingEvent(
                 $this->connection,
-                $entry,
+                $this->firstResultEntry,
                 $attributes
             ));
             $attributes = $event->getAttributes();


### PR DESCRIPTION
getEntries() contains dispatch of AttributesProcessingEvent, not present in getFirstEntry().

Resolves #252