### PR TITLE
[BUGFIX] LDAP attribute may be numeric

### DIFF
--- a/Classes/Library/Configuration.php
+++ b/Classes/Library/Configuration.php
@@ -407,9 +407,9 @@ class Configuration
         // Shortcut: if hooks are registered, take for granted extended syntax will be used
         $extended = is_array($mapping)
             && (
-                is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['extraDataProcessing'])
-                || is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['extraMergeField'])
-                || is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['getGroupsProcessing'])
+                is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['extraDataProcessing'] ?? null)
+                || is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['extraMergeField'] ?? null)
+                || is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ig_ldap_sso_auth']['getGroupsProcessing'] ?? null)
             );
 
         if (is_array($mapping) && !$extended) {

--- a/Classes/Library/Configuration.php
+++ b/Classes/Library/Configuration.php
@@ -376,7 +376,7 @@ class Configuration
         $ldapAttributes = [];
         if (is_array($mapping)) {
             foreach ($mapping as $field => $attribute) {
-                if (str_ends_with($field, '.')) {
+                if (str_ends_with((string)$field, '.')) {
                     // This is a TypoScript configuration
                     continue;
                 }


### PR DESCRIPTION
Resolves #242 

Additionally, it prevents the PHP's undefined array index warning when some hooks are used.