### PR TITLE
Fixing TYPO3 BE module docheader styles in TYPO3 v13

### DIFF
--- a/Resources/Public/Css/styles.css
+++ b/Resources/Public/Css/styles.css
@@ -8,10 +8,12 @@ div.module[data-module-name="system_IgLdapSsoAuthTxigldapssoauthm1"] > .module-b
 }
 /** [end] **/
 
-/** TYPO3 v12 fix (same as v11 actually), weird! **/
+/** TYPO3 v13 fix (same as v12/v11 actually), weird! **/
 .module-docheader {
     /** Prevent too much space between the module header and the module body **/
     position: fixed;
+    z-index: 1;
+    width: 100%;
 }
 
 dl.t3-overview-list {


### PR DESCRIPTION
Result: 
<img width="1956" height="174" alt="image" src="https://github.com/user-attachments/assets/83b2fc7e-8264-4522-bb88-39a3eab92437" />

Resolves #262 