### PR TITLE
[BUGFIX] Handle 'deleted' column for fe_users in Typo3UserRepository

### DIFF
--- a/Classes/Domain/Repository/Typo3UserRepository.php
+++ b/Classes/Domain/Repository/Typo3UserRepository.php
@@ -153,12 +153,19 @@ class Typo3UserRepository
                 }
             }
 
-            $users = $queryBuilder
+            $queryBuilder
                 ->select('*')
                 ->from($table)
                 ->where($where)
-                ->orderBy('tx_igldapssoauth_dn', 'DESC')    // rows from LDAP first...
-                ->addOrderBy('deleted', 'ASC')              // ... then privilege active records
+                ->orderBy('tx_igldapssoauth_dn', 'DESC');    // rows from LDAP first...
+
+            // Only for BE users, table fe_users has no 'deleted' column
+            if ($table !== 'fe_users') {
+                // ... then privilege active records
+                $queryBuilder->addOrderBy('deleted', 'ASC');
+            }
+
+            $users = $queryBuilder
                 ->executeQuery()
                 ->fetchAllAssociative();
         } elseif (!empty($username)) {
@@ -211,6 +218,11 @@ class Typo3UserRepository
         $data['tstamp'] = (int)$data['tstamp'];
         $data['disable'] = (int)$data['disable'];
 
+        // Remove 'deleted' column for fe_users as it does not exist in that table
+        if ($table === 'fe_users' && isset($data['deleted'])) {
+            unset($data['deleted']);
+        }
+
         $tableConnection->insert(
             $table,
             $data
@@ -255,6 +267,11 @@ class Typo3UserRepository
         // tstamp and disable needs to be int. If it's empty it's transferred as ""
         $cleanData['tstamp'] = (int)$cleanData['tstamp'];
         $cleanData['disable'] = (int)$cleanData['disable'];
+
+        // Remove 'deleted' column for fe_users as it does not exist in that table
+        if ($table === 'fe_users' && isset($cleanData['deleted'])) {
+            unset($cleanData['deleted']);
+        }
 
         $affectedRows = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable($table)


### PR DESCRIPTION
This PR addresses and fixes #279 by handling the `deleted` column properly when working with frontend users (`fe_users`), which don't have this column in their table schema.

**Implementation**
1. Query ordering (line ~155): Added conditional check to only add deleted column ordering for non-fe_users tables
- Backend users (be_users) continue to be ordered by the deleted column as before
- Frontend users (fe_users) queries skip this ordering since the column doesn't exist

2. Data insertion (line ~221): Added check to remove the deleted column from data before inserting frontend user records
Prevents database errors when inserting new frontend users from LDAP

3. Data updates (line ~271): Added check to remove the deleted column from data before updating frontend user records
Ensures update operations work correctly for frontend users without the deleted column

**Testing**
- Frontend user imports or retrievals from LDAP should now complete successfully
- Backend user imports continue to work as expected with proper `deleted` column handling
- The sync process correctly handles schema differences between user tables