### PR TITLE
[BUGFIX] Use correct classname in hook

### DIFF
--- a/Classes/Hooks/SetupModuleController.php
+++ b/Classes/Hooks/SetupModuleController.php
@@ -32,7 +32,7 @@ class SetupModuleController
      * @param array $params
      * @param \TYPO3\CMS\Setup\Controller\SetupModuleController $pObj
      */
-    public function preprocessData(array $params, \TYPO3\CMS\Setup\Controller\SetupModuleController $pObj)
+    public function preprocessData(array $params, \TYPO3\CMS\Backend\Controller\SetupModuleController $pObj)
     {
         if (empty($GLOBALS['BE_USER']->user['tx_igldapssoauth_dn'])) {
             return;


### PR DESCRIPTION
The class "SetupModuleController" was moved to another namespace. The new namespace must be used in the hook.

Resolves: xperseguers/t3ext-ig_ldap_sso_auth#288