### PR TITLE
[BUGFIX] Skip invalid FE BaseDN during SSO domain matching

### DIFF
--- a/Classes/Library/Authentication.php
+++ b/Classes/Library/Authentication.php
@@ -129,7 +129,11 @@ class Authentication
                 $domain = strtolower($domain);
 
                 $configDomain = strtolower(static::$config['users']['basedn']);
-                $configDomain = substr($configDomain, strpos($configDomain, 'dc'));
+                $dcPosition = strpos($configDomain, 'dc');
+                if ($dcPosition === false) {
+                    return false;
+                }
+                $configDomain = substr($configDomain, $dcPosition);
 
                 if ($domain !== $configDomain) {
                     // Domain does not match, stop validating here


### PR DESCRIPTION
## Problem

When Frontend SSO is enabled and multiple LDAP configuration records exist, authentication may abort during configuration evaluation.

A common setup is to have dedicated configuration records for frontend and backend authentication:

* Frontend configuration records provide `fe_users_basedn`
* Backend configuration records provide `be_users_basedn`

During frontend authentication, `AuthenticationService::getUser()` iterates over all configuration records and initializes each record in FE mode.

For configuration records that are intended for backend authentication only, the frontend configuration may not contain a valid `users.basedn`.

During SSO domain matching, the following code assumes that a valid Frontend BaseDN is always available:

```php
$configDomain = strtolower(static::$config['users']['basedn']);
$configDomain = substr($configDomain, strpos($configDomain, 'dc'));
```

If the current configuration record does not provide a valid Frontend BaseDN, `strpos()` returns `false`.

In environments with stricter type checking, this causes a runtime error because `false` is passed as the second argument to `substr()`.

As a consequence, authentication aborts before the next configuration record can be evaluated.

## Solution

Validate the result of `strpos()` before calling `substr()`.

If the current configuration record does not provide a valid Frontend BaseDN, the method should return `false` so that authentication can continue with the next available configuration record.

This preserves the existing behaviour for valid configurations while preventing authentication from aborting on configuration records that are not applicable in the current frontend authentication context.
