### PR TITLE
[TASK] Filter LDAP configurations by authentication context

### DIFF
--- a/Classes/Domain/Repository/ConfigurationRepository.php
+++ b/Classes/Domain/Repository/ConfigurationRepository.php
@@ -36,8 +36,11 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class ConfigurationRepository
 {
-    /** @var string */
-    protected $table = 'tx_igldapssoauth_config';
+    protected string $table = 'tx_igldapssoauth_config';
+
+    protected string $frontendUsersBaseDnField = 'fe_users_basedn';
+
+    protected string $backendUsersBaseDnField = 'be_users_basedn';
 
     /**
      * @var bool Set to true to also fetch disabled records (according to TCA enable fields)
@@ -79,19 +82,17 @@ class ConfigurationRepository
             )
             ->fetchAllAssociative();
 
-        $configurations = [];
-        foreach ($rows as $row) {
-            /** @var \Causal\IgLdapSsoAuth\Domain\Model\Configuration $configuration */
-            $configuration = GeneralUtility::makeInstance(Configuration::class);
-            $this->thawProperties($configuration, $row);
-            $configurations[] = $configuration;
-        }
+        return $this->hydrateConfigurations($rows);
+    }
 
-        /** @var ConfigurationLoadedEvent $event */
-        $event = GeneralUtility::makeInstance(ConfigurationLoadedEvent::class, $configurations);
-        $this->eventDispatcher->dispatch($event);
+    public function findByFrontendAuthentication(): array
+    {
+        return $this->findByUsersBaseDnField($this->frontendUsersBaseDnField);
+    }
 
-        return $event->getConfigurationRecords();
+    public function findByBackendAuthentication(): array
+    {
+        return $this->findByUsersBaseDnField($this->backendUsersBaseDnField);
     }
 
     /**
@@ -138,6 +139,43 @@ class ConfigurationRepository
     {
         $this->fetchDisabledRecords = $flag;
         return $this;
+    }
+
+    protected function findByUsersBaseDnField(string $usersBaseDnField): array
+    {
+        $rows = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getConnectionForTable($this->table)
+            ->select(
+                ['*'],
+                $this->table,
+                [
+                    sprintf('%s !=', $usersBaseDnField) => '',
+                ],
+                [],
+                [
+                    'sorting' => 'ASC',
+                ]
+            )
+            ->fetchAllAssociative();
+
+        return $this->hydrateConfigurations($rows);
+    }
+
+    protected function hydrateConfigurations(array $rows): array
+    {
+        $configurations = [];
+        foreach ($rows as $row) {
+            /** @var \Causal\IgLdapSsoAuth\Domain\Model\Configuration $configuration */
+            $configuration = GeneralUtility::makeInstance(Configuration::class);
+            $this->thawProperties($configuration, $row);
+            $configurations[] = $configuration;
+        }
+
+        /** @var ConfigurationLoadedEvent $event */
+        $event = GeneralUtility::makeInstance(ConfigurationLoadedEvent::class, $configurations);
+        $this->eventDispatcher->dispatch($event);
+
+        return $event->getConfigurationRecords();
     }
 
     /**

--- a/Classes/Domain/Repository/ConfigurationRepository.php
+++ b/Classes/Domain/Repository/ConfigurationRepository.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /*
@@ -143,19 +144,20 @@ class ConfigurationRepository
 
     protected function findByUsersBaseDnField(string $usersBaseDnField): array
     {
-        $rows = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getConnectionForTable($this->table)
-            ->select(
-                ['*'],
-                $this->table,
-                [
-                    sprintf('%s !=', $usersBaseDnField) => '',
-                ],
-                [],
-                [
-                    'sorting' => 'ASC',
-                ]
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
+            ->getQueryBuilderForTable($this->table);
+
+        $rows = $queryBuilder
+            ->select('*')
+            ->from($this->table)
+            ->where(
+                $queryBuilder->expr()->neq(
+                    $usersBaseDnField,
+                    $queryBuilder->createNamedParameter('')
+                )
             )
+            ->orderBy('sorting', 'ASC')
+            ->executeQuery()
             ->fetchAllAssociative();
 
         return $this->hydrateConfigurations($rows);

--- a/Classes/Service/AuthenticationService.php
+++ b/Classes/Service/AuthenticationService.php
@@ -97,7 +97,9 @@ class AuthenticationService extends \TYPO3\CMS\Core\Authentication\Authenticatio
 
         /** @var ConfigurationRepository $configurationRepository */
         $configurationRepository = GeneralUtility::makeInstance(ConfigurationRepository::class);
-        $configurationRecords = $configurationRepository->findAll();
+        $configurationRecords = $typo3Mode === 'FE'
+            ? $configurationRepository->findByFrontendAuthentication()
+            : $configurationRepository->findByBackendAuthentication();
 
         if (empty($configurationRecords)) {
             // Early return since LDAP is not configured


### PR DESCRIPTION
## Summary

Only load LDAP configuration records that are relevant for the current authentication context.

Frontend authentication now loads only configuration records with a frontend user BaseDN configured, while backend authentication only loads configuration records with a backend user BaseDN configured.

## Motivation

`AuthenticationService::getUser()` currently loads all LDAP configuration records and iterates over them regardless of the current authentication context.

In installations with dedicated frontend and backend LDAP configurations, this means that frontend authentication evaluates backend-only configuration records and vice versa.

By filtering configuration records at repository level, the authentication service only processes configurations that can actually participate in the current authentication flow.

## Benefits

* Reduces the number of configuration records evaluated during authentication.
* Avoids unnecessary LDAP authentication attempts.
* Makes the authentication flow more explicit by separating frontend and backend configuration lookups.
* Improves performance for installations with a large number of LDAP configuration records.

## Implementation

Introduce dedicated repository methods:

* `findByFrontendAuthentication()`
* `findByBackendAuthentication()`

These methods filter configuration records based on the presence of the corresponding user BaseDN field:

* `fe_users_basedn`
* `be_users_basedn`

`AuthenticationService::getUser()` now selects the appropriate repository method depending on the current TYPO3 authentication context (`FE` or `BE`).
