### PR TITLE
[BUGFIX] Prevent multiple encodings of user_settings

### DIFF
--- a/Classes/Domain/Repository/Typo3UserRepository.php
+++ b/Classes/Domain/Repository/Typo3UserRepository.php
@@ -245,6 +245,11 @@ class Typo3UserRepository
             unset($cleanData['deleted']);
         }
 
+        // @TODO: Do not remove until https://review.typo3.org/c/Packages/TYPO3.CMS/+/89293 is merged, otherwise the value will be JSON-encoded twice.
+        if (isset($cleanData['user_settings'])) {
+            unset($cleanData['user_settings']);
+        }
+
         $affectedRows = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getConnectionForTable($table)
             ->update(


### PR DESCRIPTION
Since #108832, backend user settings are stored as JSON in be_users. When syncing backend users, this extension fetches the whole user, including its settings as JSON string, and passes the whole data again to update it.

This leads to typo3 json_encoding() this string before persisting it again.
Every time the user is persisted, another escaping character \ is added.

When running the import/sync command periodically, this leads to the be_users table growing non-stop.

To fix this, exclude user settings from the updated data for now.

Resolves: #292